### PR TITLE
fix(milvus): resolve data-plane endpoint server-side

### DIFF
--- a/src/zilliz_mcp_server/common/openapi_client.py
+++ b/src/zilliz_mcp_server/common/openapi_client.py
@@ -1,8 +1,16 @@
+import ipaddress
 import requests
 from requests.exceptions import HTTPError
 from typing import Dict, Any, Optional
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from zilliz_mcp_server.settings import config
+
+# Public Zilliz Cloud data-plane host suffixes. A leading dot is required so
+# lookalikes such as "notzillizcloud.com" cannot match.
+_ALLOWED_DATA_PLANE_HOST_SUFFIXES = (
+    ".zillizcloud.com",
+    ".zilliz.com.cn",
+)
 
 
 def _get_headers() -> Dict[str, str]:
@@ -36,6 +44,84 @@ def _parse_response(response) -> Dict[str, Any]:
         raise Exception(f"Business error: {error_message}")
     
     return json_data
+
+
+def _is_ip_address(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _hostname_is_allowed_zilliz_cloud(hostname: str) -> bool:
+    host = hostname.rstrip(".").lower()
+    for suffix in _ALLOWED_DATA_PLANE_HOST_SUFFIXES:
+        apex = suffix.lstrip(".")
+        if host.endswith(suffix) and host != apex:
+            return True
+    return False
+
+
+def _assert_safe_data_plane_url(endpoint: str, cluster_id: str) -> str:
+    """Validate a resolved data-plane base URL and return a normalized origin.
+
+    Must be called before any credential-bearing data-plane request.
+    """
+    if not endpoint or not str(endpoint).strip():
+        raise ValueError("cluster connectAddress is required and cannot be empty")
+
+    parsed = urlparse(endpoint.strip())
+    if parsed.scheme != "https":
+        raise ValueError("data-plane endpoint must use https")
+    if parsed.username or parsed.password:
+        raise ValueError("data-plane endpoint must not contain userinfo")
+    if parsed.query or parsed.fragment:
+        raise ValueError("data-plane endpoint must not contain query or fragment")
+    if parsed.path not in ("", "/"):
+        raise ValueError("data-plane endpoint must not contain a path")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("data-plane endpoint hostname is required")
+
+    hostname = hostname.rstrip(".").lower()
+    if _is_ip_address(hostname):
+        raise ValueError("data-plane endpoint must not be an IP address")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ValueError("data-plane endpoint must not be localhost")
+    if not _hostname_is_allowed_zilliz_cloud(hostname):
+        raise ValueError("data-plane endpoint hostname is not an allowed Zilliz Cloud host")
+
+    labels = hostname.split(".")
+    if cluster_id.strip().lower() not in labels:
+        raise ValueError("data-plane endpoint hostname must include the requested cluster_id")
+
+    netloc = hostname
+    if parsed.port:
+        netloc = f"{hostname}:{parsed.port}"
+    return f"https://{netloc}/"
+
+
+def _resolve_cluster_endpoint(cluster_id: str, region_id: str) -> str:
+    """Resolve the data-plane URL from control-plane cluster metadata."""
+    response = control_plane_api_request(f"/v2/clusters/{cluster_id}", method="GET")
+    data = response.get("data") or {}
+
+    returned_cluster_id = str(data.get("clusterId") or "").strip()
+    if returned_cluster_id and returned_cluster_id.lower() != cluster_id.strip().lower():
+        raise ValueError("resolved cluster_id does not match the requested cluster")
+
+    returned_region_id = str(data.get("regionId") or "").strip()
+    if returned_region_id and returned_region_id.lower() != region_id.strip().lower():
+        raise ValueError("region_id does not match the resolved cluster")
+
+    connect_address = data.get("connectAddress")
+    if not connect_address or not str(connect_address).strip():
+        raise ValueError("cluster connectAddress is missing from control-plane response")
+
+    # Validate even trusted metadata so an unexpected address never receives the token.
+    return _assert_safe_data_plane_url(str(connect_address), cluster_id)
 
 
 def get(url: str, params_map: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -82,26 +168,29 @@ def control_plane_api_request(uri: str, params_map: Optional[Dict[str, Any]] = N
         raise ValueError(f"Unsupported method: {method}")
 
 
-def data_plane_api_request(endpoint:str, uri: str, cluster_id: str, region_id: str, params_map: Optional[Dict[str, Any]] = None, body_map: Optional[Dict[str, Any]] = None, method: str = "GET") -> Dict[str, Any]:
-    """Data Plane API request"""
-    # Validate required parameters
+def data_plane_api_request(uri: str, cluster_id: str, region_id: str, params_map: Optional[Dict[str, Any]] = None, body_map: Optional[Dict[str, Any]] = None, method: str = "GET") -> Dict[str, Any]:
+    """Data Plane API request.
+
+    The data-plane base URL is resolved from control-plane cluster metadata
+    and checked against the Zilliz Cloud allowlist before any token is sent.
+    """
     if not uri or not uri.strip():
         raise ValueError("uri is required and cannot be empty")
     if not cluster_id or not cluster_id.strip():
         raise ValueError("cluster_id is required and cannot be empty")
     if not region_id or not region_id.strip():
         raise ValueError("region_id is required and cannot be empty")
-    
-    # Ensure proper URL joining by removing leading slash from uri and ensuring base ends with slash
-    base_url = endpoint.rstrip('/') + '/'
+
+    method_upper = method.upper()
+    if method_upper not in ("GET", "POST", "DELETE"):
+        raise ValueError(f"Unsupported method: {method}")
+
+    base_url = _resolve_cluster_endpoint(cluster_id, region_id)
     clean_uri = uri.lstrip('/')
     url = urljoin(base_url, clean_uri)
-    
-    if method.upper() == "GET":
+
+    if method_upper == "GET":
         return get(url, params_map)
-    elif method.upper() == "POST":
+    elif method_upper == "POST":
         return post(url, params_map, body_map)
-    elif method.upper() == "DELETE":
-        return delete(url, params_map)
-    else:
-        raise ValueError(f"Unsupported method: {method}") 
+    return delete(url, params_map) 

--- a/src/zilliz_mcp_server/tools/milvus/milvus_tools.py
+++ b/src/zilliz_mcp_server/tools/milvus/milvus_tools.py
@@ -12,14 +12,13 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 
 
 @zilliz_mcp.tool()
-async def list_databases(cluster_id: str, region_id: str, endpoint: str) -> str:
+async def list_databases(cluster_id: str, region_id: str) -> str:
     """
     List all databases in the current cluster.
     
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
     Returns:
         List of database names
         Example:
@@ -31,13 +30,12 @@ async def list_databases(cluster_id: str, region_id: str, endpoint: str) -> str:
     """
     try:
         # Log request
-        logger.info(f"LIST_DATABASES: endpoint={endpoint}, cluster_id={cluster_id}")
+        logger.info(f"LIST_DATABASES: cluster_id={cluster_id}")
         
         # Build request body (empty for list databases)
         body = {}
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/databases/list",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -59,14 +57,13 @@ async def list_databases(cluster_id: str, region_id: str, endpoint: str) -> str:
 
 
 @zilliz_mcp.tool()
-async def list_collections(cluster_id: str, region_id: str, endpoint: str, db_name: str = "") -> str:
+async def list_collections(cluster_id: str, region_id: str, db_name: str = "") -> str:
     """
     List all collection names in the specified database.
     
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         db_name: The name of an existing database. Pass explicit dbName or leave empty when cluster is free or serverless
     Returns:
         JSON string containing list of collection names
@@ -82,10 +79,9 @@ async def list_collections(cluster_id: str, region_id: str, endpoint: str, db_na
             body["dbName"] = db_name
         
         # Log request
-        logger.info(f"LIST_COLLECTIONS: endpoint={endpoint}, cluster_id={cluster_id}, db_name={db_name}")
+        logger.info(f"LIST_COLLECTIONS: cluster_id={cluster_id}, db_name={db_name}")
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/collections/list",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -113,7 +109,6 @@ async def list_collections(cluster_id: str, region_id: str, endpoint: str, db_na
 async def create_collection(
     cluster_id: str, 
     region_id: str, 
-    endpoint: str,
     collection_name: str, 
     dimension: int,
     db_name: str = "",
@@ -129,7 +124,6 @@ async def create_collection(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of the collection to create
         dimension: The number of dimensions a vector value should have
         db_name: The name of the database. Pass explicit dbName or leave empty when cluster is free or serverless
@@ -173,7 +167,6 @@ async def create_collection(
             }
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/collections/create",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -195,7 +188,6 @@ async def create_collection(
 async def describe_collection(
     cluster_id: str, 
     region_id: str, 
-    endpoint: str,
     collection_name: str,
     db_name: str = ""
 ) -> str:
@@ -205,7 +197,6 @@ async def describe_collection(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of the collection to describe
         db_name: The name of the database. Pass explicit dbName or leave empty when cluster is free or serverless
     Returns:
@@ -275,7 +266,6 @@ async def describe_collection(
             body["dbName"] = db_name
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/collections/describe",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -299,7 +289,6 @@ async def describe_collection(
 async def insert_entities(
     cluster_id: str,
     region_id: str, 
-    endpoint: str,
     collection_name: str,
     data: Union[Dict[str, Any], List[Dict[str, Any]]],
     db_name: str = ""
@@ -310,7 +299,6 @@ async def insert_entities(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of an existing collection
         data: An entity object or an array of entity objects. Note that the keys in an entity object should match the collection schema
         db_name: The name of the target database. Pass explicit dbName or leave empty when cluster is free or serverless
@@ -342,7 +330,6 @@ async def insert_entities(
             body["dbName"] = db_name
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/entities/insert",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -366,7 +353,6 @@ async def insert_entities(
 async def delete_entities(
     cluster_id: str,
     region_id: str,
-    endpoint: str,
     collection_name: str,
     filter: str,
     db_name: str = "",
@@ -378,7 +364,6 @@ async def delete_entities(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of an existing collection
         filter: A scalar filtering condition to filter matching entities. You can set this parameter to an empty string to skip scalar filtering. To build a scalar filtering condition, refer to Reference on Scalar Filters
         db_name: The name of the target database. Pass explicit dbName or leave empty when cluster is free or serverless
@@ -412,7 +397,6 @@ async def delete_entities(
             body["partitionName"] = partition_name
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/entities/delete",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -434,7 +418,6 @@ async def delete_entities(
 async def search(
     cluster_id: str,
     region_id: str,
-    endpoint: str,
     collection_name: str,
     data: List[List[float]],
     anns_field: str,
@@ -455,7 +438,6 @@ async def search(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of the collection to which this operation applies
         data: A list of vector embeddings. Zilliz Cloud searches for the most similar vector embeddings to the specified ones
         anns_field: The name of the vector field
@@ -540,7 +522,6 @@ async def search(
             body["consistencyLevel"] = consistency_level
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/entities/search",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -564,7 +545,6 @@ async def search(
 async def query(
     cluster_id: str,
     region_id: str,
-    endpoint: str,
     collection_name: str,
     filter: str,
     db_name: str = "",
@@ -579,7 +559,6 @@ async def query(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of the collection to which this operation applies
         filter: The filter used to find matches for the search
         db_name: The name of the database. Pass explicit dbName or leave empty when cluster is free or serverless
@@ -639,7 +618,6 @@ async def query(
             body["offset"] = offset
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/entities/query",
             cluster_id=cluster_id,
             region_id=region_id,
@@ -663,7 +641,6 @@ async def query(
 async def hybrid_search(
     cluster_id: str,
     region_id: str,
-    endpoint: str,
     collection_name: str,
     search_requests: List[Dict[str, Any]],
     rerank_strategy: str,
@@ -680,7 +657,6 @@ async def hybrid_search(
     Args:
         cluster_id: ID of the cluster
         region_id: ID of the cloud region hosting the cluster
-        endpoint: The cluster endpoint URL. Can be obtained by calling describe_cluster and using the connect_address field
         collection_name: The name of the collection to which this operation applies
         search_requests: List of search parameters for different vector fields. Each search request should contain:
             - data: A list of vector embeddings
@@ -750,7 +726,6 @@ async def hybrid_search(
             body["consistencyLevel"] = consistency_level
         
         response = openapi_client.data_plane_api_request(
-            endpoint=endpoint,
             uri="/v2/vectordb/entities/hybrid_search",
             cluster_id=cluster_id,
             region_id=region_id,

--- a/tests/unit/test_openapi_client.py
+++ b/tests/unit/test_openapi_client.py
@@ -252,51 +252,175 @@ class TestControlPlaneApiRequest:
             openapi_client.control_plane_api_request("/v2/test", method="PATCH")
 
 
+CLUSTER_ID = "in01-test123"
+REGION_ID = "gcp-us-west1"
+SAFE_CONNECT_ADDRESS = "https://in01-test123.api.gcp-us-west1.zillizcloud.com"
+CONTROL_PLANE_URI = "https://api.cloud.zilliz.com"
+
+
+def _add_cluster_describe(connect_address=SAFE_CONNECT_ADDRESS, cluster_id=CLUSTER_ID, region_id=REGION_ID):
+    responses.add(
+        responses.GET,
+        f"{CONTROL_PLANE_URI}/v2/clusters/{cluster_id}",
+        json={
+            "code": 0,
+            "data": {
+                "clusterId": cluster_id,
+                "regionId": region_id,
+                "connectAddress": connect_address,
+            },
+        },
+        status=200,
+    )
+
+
+class TestAssertSafeDataPlaneUrl:
+    """Allowlist checks must reject untrusted destinations before any token is sent."""
+
+    def test_accepts_official_serverless_host(self):
+        result = openapi_client._assert_safe_data_plane_url(SAFE_CONNECT_ADDRESS, CLUSTER_ID)
+        assert result == SAFE_CONNECT_ADDRESS + "/"
+
+    def test_accepts_official_dedicated_host_with_port(self):
+        url = "https://in01-test123.aws-us-west-2.vectordb.zillizcloud.com:19530"
+        result = openapi_client._assert_safe_data_plane_url(url, CLUSTER_ID)
+        assert result == url + "/"
+
+    def test_accepts_china_cloud_host(self):
+        url = "https://in01-test123.ali-cn-hangzhou.vectordb.zilliz.com.cn:19530"
+        result = openapi_client._assert_safe_data_plane_url(url, CLUSTER_ID)
+        assert result == url + "/"
+
+    @pytest.mark.parametrize("url", [
+        "https://evil.example",
+        "http://in01-test123.api.gcp-us-west1.zillizcloud.com",
+        "https://127.0.0.1",
+        "https://10.0.0.1",
+        "https://localhost",
+        "https://in01-test123.zillizcloud.com.evil.com",
+        "https://notzillizcloud.com",
+        "https://attacker@in01-test123.api.gcp-us-west1.zillizcloud.com",
+        "https://in01-other.api.gcp-us-west1.zillizcloud.com",
+        "https://in01-test123.api.gcp-us-west1.zillizcloud.com/extra",
+        "https://in01-test123.api.gcp-us-west1.zillizcloud.com?x=1",
+    ])
+    def test_rejects_untrusted_urls(self, url):
+        with pytest.raises(ValueError):
+            openapi_client._assert_safe_data_plane_url(url, CLUSTER_ID)
+
+
 class TestDataPlaneApiRequest:
     """Test cases for data_plane_api_request function."""
 
     def test_empty_uri_raises_error(self):
         """Test that empty URI raises ValueError."""
         with pytest.raises(ValueError, match="uri is required and cannot be empty"):
-            openapi_client.data_plane_api_request("", "", "cluster1", "region1")
+            openapi_client.data_plane_api_request("", CLUSTER_ID, REGION_ID)
 
     def test_empty_cluster_id_raises_error(self):
         """Test that empty cluster_id raises ValueError."""
         with pytest.raises(ValueError, match="cluster_id is required and cannot be empty"):
-            openapi_client.data_plane_api_request("https://test.com", "/v2/test", "", "region1")
+            openapi_client.data_plane_api_request("/v2/test", "", REGION_ID)
 
     def test_empty_region_id_raises_error(self):
         """Test that empty region_id raises ValueError."""
         with pytest.raises(ValueError, match="region_id is required and cannot be empty"):
-            openapi_client.data_plane_api_request("https://test.com", "/v2/test", "cluster1", "")
-
-    @responses.activate
-    def test_data_plane_post_request(self):
-        """Test successful data plane POST request."""
-        responses.add(
-            responses.POST,
-            "https://test-endpoint.com/v2/vectordb/collections/list",
-            json={"code": 0, "data": ["collection1", "collection2"]},
-            status=200
-        )
-        
-        with patch('zilliz_mcp_server.common.openapi_client.config') as mock_config:
-            mock_config.token = "test-token"
-            
-            result = openapi_client.data_plane_api_request(
-                endpoint="https://test-endpoint.com",
-                uri="/v2/vectordb/collections/list",
-                cluster_id="cluster1",
-                region_id="region1",
-                body_map={"dbName": "default"},
-                method="POST"
-            )
-            
-        assert result == {"code": 0, "data": ["collection1", "collection2"]}
+            openapi_client.data_plane_api_request("/v2/test", CLUSTER_ID, "")
 
     def test_unsupported_method_raises_error(self):
         """Test that unsupported HTTP method raises ValueError."""
         with pytest.raises(ValueError, match="Unsupported method: PUT"):
             openapi_client.data_plane_api_request(
-                "https://test.com", "/v2/test", "cluster1", "region1", method="PUT"
-            ) 
+                "/v2/test", CLUSTER_ID, REGION_ID, method="PUT"
+            )
+
+    @responses.activate
+    def test_data_plane_post_request_resolves_cluster_endpoint(self):
+        """Test successful data plane POST after resolving connectAddress."""
+        _add_cluster_describe()
+        responses.add(
+            responses.POST,
+            f"{SAFE_CONNECT_ADDRESS}/v2/vectordb/collections/list",
+            json={"code": 0, "data": ["collection1", "collection2"]},
+            status=200,
+        )
+
+        with patch("zilliz_mcp_server.common.openapi_client.config") as mock_config:
+            mock_config.cloud_uri = CONTROL_PLANE_URI
+            mock_config.token = "test-token"
+
+            result = openapi_client.data_plane_api_request(
+                uri="/v2/vectordb/collections/list",
+                cluster_id=CLUSTER_ID,
+                region_id=REGION_ID,
+                body_map={"dbName": "default"},
+                method="POST",
+            )
+
+        assert result == {"code": 0, "data": ["collection1", "collection2"]}
+        assert len(responses.calls) == 2
+        assert responses.calls[0].request.url == f"{CONTROL_PLANE_URI}/v2/clusters/{CLUSTER_ID}"
+        assert responses.calls[1].request.url == f"{SAFE_CONNECT_ADDRESS}/v2/vectordb/collections/list"
+        assert responses.calls[1].request.headers["Authorization"] == "Bearer test-token"
+
+    @responses.activate
+    def test_untrusted_connect_address_does_not_send_data_plane_request(self):
+        """Attacker-controlled connectAddress must not receive the token."""
+        _add_cluster_describe(connect_address="https://evil.example")
+        responses.add(
+            responses.POST,
+            "https://evil.example/v2/vectordb/databases/list",
+            json={"code": 0, "data": []},
+            status=200,
+        )
+
+        with patch("zilliz_mcp_server.common.openapi_client.config") as mock_config:
+            mock_config.cloud_uri = CONTROL_PLANE_URI
+            mock_config.token = "test-token"
+
+            with pytest.raises(ValueError, match="not an allowed Zilliz Cloud host"):
+                openapi_client.data_plane_api_request(
+                    uri="/v2/vectordb/databases/list",
+                    cluster_id=CLUSTER_ID,
+                    region_id=REGION_ID,
+                    method="POST",
+                )
+
+        assert len(responses.calls) == 1
+        assert "evil.example" not in responses.calls[0].request.url
+
+    @responses.activate
+    def test_region_mismatch_does_not_send_data_plane_request(self):
+        _add_cluster_describe(region_id="aws-us-west-2")
+
+        with patch("zilliz_mcp_server.common.openapi_client.config") as mock_config:
+            mock_config.cloud_uri = CONTROL_PLANE_URI
+            mock_config.token = "test-token"
+
+            with pytest.raises(ValueError, match="region_id does not match"):
+                openapi_client.data_plane_api_request(
+                    uri="/v2/vectordb/databases/list",
+                    cluster_id=CLUSTER_ID,
+                    region_id=REGION_ID,
+                    method="POST",
+                )
+
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_missing_connect_address_does_not_send_data_plane_request(self):
+        _add_cluster_describe(connect_address="")
+
+        with patch("zilliz_mcp_server.common.openapi_client.config") as mock_config:
+            mock_config.cloud_uri = CONTROL_PLANE_URI
+            mock_config.token = "test-token"
+
+            with pytest.raises(ValueError, match="connectAddress is missing"):
+                openapi_client.data_plane_api_request(
+                    uri="/v2/vectordb/databases/list",
+                    cluster_id=CLUSTER_ID,
+                    region_id=REGION_ID,
+                    method="POST",
+                )
+
+        assert len(responses.calls) == 1 

--- a/tests/unit/tools/test_milvus_tools.py
+++ b/tests/unit/tools/test_milvus_tools.py
@@ -68,12 +68,11 @@ class TestListDatabases:
             "data": ["default", "test_db"]
         }
         
-        result = await list_databases("cluster1", "region1", "https://test.endpoint.com")
+        result = await list_databases("cluster1", "region1")
         result_data = json.loads(result)
         
         assert result_data == ["default", "test_db"]
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/databases/list",
             cluster_id="cluster1",
             region_id="region1",
@@ -89,7 +88,7 @@ class TestListDatabases:
         mock_client.data_plane_api_request.side_effect = Exception("Connection failed")
         
         with pytest.raises(Exception, match="Failed to list databases: Connection failed"):
-            await list_databases("cluster1", "region1", "https://test.endpoint.com")
+            await list_databases("cluster1", "region1")
 
 
 class TestListCollections:
@@ -105,12 +104,11 @@ class TestListCollections:
             "data": ["collection1", "collection2"]
         }
         
-        result = await list_collections("cluster1", "region1", "https://test.endpoint.com", "test_db")
+        result = await list_collections("cluster1", "region1", "test_db")
         result_data = json.loads(result)
         
         assert result_data == ["collection1", "collection2"]
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/collections/list",
             cluster_id="cluster1",
             region_id="region1",
@@ -128,10 +126,9 @@ class TestListCollections:
             "data": ["collection1"]
         }
         
-        result = await list_collections("cluster1", "region1", "https://test.endpoint.com")
+        result = await list_collections("cluster1", "region1")
         
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/collections/list",
             cluster_id="cluster1",
             region_id="region1",
@@ -153,7 +150,6 @@ class TestCreateCollection:
         result = await create_collection(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             dimension=128
         )
@@ -171,7 +167,6 @@ class TestCreateCollection:
             "vectorFieldName": "vector"
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/collections/create",
             cluster_id="cluster1",
             region_id="region1",
@@ -189,7 +184,6 @@ class TestCreateCollection:
         result = await create_collection(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             dimension=128,
             id_type="VarChar"
@@ -206,7 +200,6 @@ class TestCreateCollection:
             "params": {"max_length": 255}
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/collections/create",
             cluster_id="cluster1",
             region_id="region1",
@@ -224,7 +217,6 @@ class TestCreateCollection:
         result = await create_collection(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             dimension=128,
             db_name="test_db"
@@ -248,7 +240,6 @@ class TestDescribeCollection:
         result = await describe_collection(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection"
         )
         
@@ -257,7 +248,6 @@ class TestDescribeCollection:
         
         expected_body = {"collectionName": "test_collection"}
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/collections/describe",
             cluster_id="cluster1",
             region_id="region1",
@@ -287,7 +277,6 @@ class TestInsertEntities:
         result = await insert_entities(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             data=test_data
         )
@@ -301,7 +290,6 @@ class TestInsertEntities:
             "data": test_data
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/insert",
             cluster_id="cluster1",
             region_id="region1",
@@ -324,7 +312,6 @@ class TestInsertEntities:
         result = await insert_entities(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             data=test_data
         )
@@ -355,7 +342,6 @@ class TestSearch:
         result = await search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             data=search_vectors,
             anns_field="vector",
@@ -372,7 +358,6 @@ class TestSearch:
             "limit": 10
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/search",
             cluster_id="cluster1",
             region_id="region1",
@@ -395,7 +380,6 @@ class TestSearch:
         result = await search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             data=search_vectors,
             anns_field="vector",
@@ -429,7 +413,6 @@ class TestQuery:
         result = await query(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             filter="id > 0"
         )
@@ -443,7 +426,6 @@ class TestQuery:
             "limit": 100
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/query",
             cluster_id="cluster1",
             region_id="region1",
@@ -464,7 +446,6 @@ class TestQuery:
         result = await query(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             filter="id > 0",
             limit=100,
@@ -495,7 +476,6 @@ class TestDeleteEntities:
         result = await delete_entities(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             filter="id in [1, 2, 3]"
         )
@@ -508,7 +488,6 @@ class TestDeleteEntities:
             "filter": "id in [1, 2, 3]"
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/delete",
             cluster_id="cluster1",
             region_id="region1",
@@ -530,7 +509,6 @@ class TestDeleteEntities:
         result = await delete_entities(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             filter="id in [1, 2, 3]",
             db_name="test_db",
@@ -544,7 +522,6 @@ class TestDeleteEntities:
             "partitionName": "test_partition"
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/delete",
             cluster_id="cluster1",
             region_id="region1",
@@ -596,7 +573,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="rrf",
@@ -617,7 +593,6 @@ class TestHybridSearch:
             "limit": 10
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/hybrid_search",
             cluster_id="cluster1",
             region_id="region1",
@@ -655,7 +630,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="weighted",
@@ -684,7 +658,6 @@ class TestHybridSearch:
             "consistencyLevel": "Strong"
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/hybrid_search",
             cluster_id="cluster1",
             region_id="region1",
@@ -721,7 +694,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="rrf",
@@ -757,7 +729,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="rrf",
@@ -788,8 +759,7 @@ class TestHybridSearch:
             await hybrid_search(
                 cluster_id="cluster1",
                 region_id="region1",
-                endpoint="https://test.endpoint.com",
-                collection_name="test_collection",
+                    collection_name="test_collection",
                 search_requests=search_requests,
                 rerank_strategy="rrf",
                 rerank_params={"k": 10},
@@ -833,7 +803,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="rrf",
@@ -876,7 +845,6 @@ class TestHybridSearch:
         result = await hybrid_search(
             cluster_id="cluster1",
             region_id="region1",
-            endpoint="https://test.endpoint.com",
             collection_name="test_collection",
             search_requests=search_requests,
             rerank_strategy="rrf",
@@ -899,7 +867,6 @@ class TestHybridSearch:
             "outputFields": ["id", "category", "title"]
         }
         mock_client.data_plane_api_request.assert_called_once_with(
-            endpoint="https://test.endpoint.com",
             uri="/v2/vectordb/entities/hybrid_search",
             cluster_id="cluster1",
             region_id="region1",


### PR DESCRIPTION
## Summary

- Remove caller-controlled `endpoint` from all Milvus data-plane tools (`list_databases`, `list_collections`, `create_collection`, `describe_collection`, `insert_entities`, `delete_entities`, `search`, `query`, `hybrid_search`).
- Resolve the data-plane base URL server-side from control-plane cluster metadata (`GET /v2/clusters/{cluster_id}` → `connectAddress`).
- Before sending `ZILLIZ_CLOUD_TOKEN`, require `https`, an official Zilliz Cloud hostname (`*.zillizcloud.com` / `*.zilliz.com.cn`), and a hostname label that matches the requested `cluster_id`. Reject IP literals, localhost, userinfo, and lookalike hosts.
- Validation failure makes no data-plane request, so the token is not forwarded to an untrusted destination.

This closes a credential-forwarding issue: a caller (or prompt-injected agent) could previously set `endpoint` to an arbitrary URL and receive the server-held API token in the `Authorization` header.

**Breaking change:** data-plane tools no longer accept `endpoint`. Callers should pass only `cluster_id` and `region_id`.

**Out of scope:** MCP HTTP/SSE transport still has no auth. That is a separate hardening item. Private Link / custom data-plane hostnames outside the official suffixes will be rejected.

## Test plan

- [x] `uv run pytest tests/unit/ -v` — 94 passed
- [x] New allowlist tests reject `evil.example`, `http://`, IPs, localhost, userinfo, path/query, and hostnames that omit `cluster_id`
- [x] Failed validation issues only the control-plane describe call; no data-plane request is sent
- [ ] Manual: call `list_databases(cluster_id, region_id)` against a real cluster and confirm it still works without `endpoint`